### PR TITLE
Use content type machine name for revisions query

### DIFF
--- a/node_revision_history.module
+++ b/node_revision_history.module
@@ -223,7 +223,7 @@ function node_revision_history_listing_form_page_three($form, &$form_state) {
 
   //for each node type count how many revision exist.
   foreach (node_type_get_names() as $type => $name) {
-    $revisions = node_revision_history_candidates($name, $threshold);
+    $revisions = node_revision_history_candidates($type, $threshold);
     if(!empty($revisions)){
       $revision_count[$name] = $revisions;
     }


### PR DESCRIPTION
This patch allows the module to delete revisions for content types whose machine name does not match their human-readable name. Fixes #1